### PR TITLE
FLTR-8425: Removed call to close the bottom sheet from _ModalBottomSheetState._handleDragUpdate

### DIFF
--- a/lib/src/bottom_sheet.dart
+++ b/lib/src/bottom_sheet.dart
@@ -195,17 +195,6 @@ class _ModalBottomSheetState extends State<ModalBottomSheet>
 
     final progress = primaryDelta / (_childHeight ?? primaryDelta);
 
-    if (widget.shouldClose != null && hasReachedWillPopThreshold) {
-      _cancelClose();
-      final canClose = await shouldClose();
-      if (canClose) {
-        _close();
-        return;
-      } else {
-        _cancelClose();
-      }
-    }
-
     // Bounce top
     final bounce = widget.bounce == true;
     final shouldBounce = _bounceDragController.value > 0;


### PR DESCRIPTION
In this PR, the `_ModalBottomSheetState._handleDragUpdate()` will no longer dismiss the modal sheet.